### PR TITLE
Implement Antora Assembler PDF extension (and various related changes to structure and content)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ For more about the project and its components, see the `README.adoc` file in the
 
 == Copyright and licence
 
-Copyright 2020 Eric Weston and the Epic Remastered project contributors.
+Copyright 2020–{docyear} Eric Weston and the Epic Remastered project contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -26,5 +26,5 @@ This publication is completely unofficial and in no way endorsed by Games Worksh
 
 .Trademark list
 ****
-Adeptus Astartes, Battlefleet Gothic, Blood Angels, Cadian, Catachan, the Chaos device, the Chaos logo, Citadel, the Citadel device, Codex, Daemonhunters, Dark Angels, Dark Eldar, the Double-Headed/Imperial Eagle device (Aquila), ’Eavy Metal, Eldar, Eldar symbol devices, Epic, Eye of Terror, Fanatic, the Fanatic logo, the Fanatic II logo, Fire Warrior, Forge World, Games Workshop, Games Workshop logo, Genestealer, Golden Demon, Great Unclean One, Keeper of Secrets, Khemri, Khorne, Kroot, Lord of Change, Necron, Nurgle, Ork, Ork skull devices, Sisters of Battle, Slaanesh, Space Marine, Space Marine chapters, Space Marine chapter logos, Tau, the Tau caste designations, Tyranid, Tzeentch, Ultramarines, Warhammer, Warhammer 40k device, Warhammer World logo, White Dwarf, the White Dwarf logo, and all associated marks, names, races, race insignia, characters, vehicles, locations, units, illustrations and images from the Warhammer 40,000 universe are either ®, ™ and/or © Copyright Games Workshop Ltd, variably registered in the UK and other countries around the world. Used without permission. No challenge to their status intended. All Rights Reserved to their respective owners.
+Adeptus Astartes, Battlefleet Gothic, Blood Angels, Cadian, Catachan, the Chaos device, the Chaos logo, Citadel, the Citadel device, Codex, Daemonhunters, Dark Angels, Dark Eldar, the Double-Headed/Imperial Eagle device (Aquila), 'Eavy Metal, Eldar, Eldar symbol devices, Epic, Eye of Terror, Fanatic, the Fanatic logo, the Fanatic II logo, Fire Warrior, Forge World, Games Workshop, Games Workshop logo, Genestealer, Golden Demon, Great Unclean One, Keeper of Secrets, Khemri, Khorne, Kroot, Lord of Change, Necron, Nurgle, Ork, Ork skull devices, Sisters of Battle, Slaanesh, Space Marine, Space Marine chapters, Space Marine chapter logos, Tau, the Tau caste designations, Tyranid, Tzeentch, Ultramarines, Warhammer, Warhammer 40k device, Warhammer World logo, White Dwarf, the White Dwarf logo, and all associated marks, names, races, race insignia, characters, vehicles, locations, units, illustrations and images from the Warhammer 40,000 universe are either ®, ™ and/or © Copyright Games Workshop Ltd, variably registered in the UK and other countries around the world. Used without permission. No challenge to their status intended. All Rights Reserved to their respective owners.
 ****

--- a/antora.yml
+++ b/antora.yml
@@ -10,3 +10,20 @@ nav:
 - modules/campaigns/nav.adoc
 - modules/more/nav.adoc
 - modules/experimental/nav.adoc
+
+asciidoc:
+  attributes:
+    # Attributes for this component that have values that authors may need to change from time to time:
+
+    revnumber: Pre-alpha
+    
+    # Attributes for this component that have values that we expect to set only once:
+
+    # `doctype` controls various settings that relate mainly to PDF outputs.
+    # Among other things, it controls special sections, such as the colophon, recto/verso page
+    # arrangements, and more. (See https://docs.asciidoctor.org/asciidoc/latest/sections/styles).
+    doctype: book
+    # `media` controls various settings that relate to PDF output.
+    # (See https://docs.asciidoctor.org/pdf-converter/latest/theme/print-and-prepress).
+    media: prepress 
+    toc-title: Contents

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,5 +1,24 @@
 = Battles
 
+// Exclude from PDF output (show only in HTML output).
+ifndef::loader-assembler[]
+_Version: {revnumber} | Date of this build: {docdate}_
+endif::[]
+
+// Frontmatter to show only in PDF output.
+ifdef::loader-assembler[]
+// Colophon: Show only in PDF output.
+[preface]
+include::home::partial$colophon.adoc[]
+endif::[]
+
+// Table of contents: Not relevant for HTML output. Make sure that this code is *after* all content that we want to treat as frontmatter in the PDF output.
+ifdef::loader-assembler[]
+include::home::partial$toc.adoc[]
+endif::[]
+
+== {project-name}: Battles -- the scenarios and setup for play
+
 Here you'll find guidance and ideas on how to set up a game of {project-name}.
 You'll also find scenario special rules; these are particular to some scenarios, so we detail them here rather than in the _Core_ component.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,23 +1,9 @@
 = Battles
 
-// Exclude from PDF output (show only in HTML output).
-ifndef::loader-assembler[]
-_Version: {revnumber} | Date of this build: {docdate}_
-endif::[]
-
-// Frontmatter to show only in PDF output.
-ifdef::loader-assembler[]
-// Colophon: Show only in PDF output.
-[preface]
+// Frontmatter -- mostly for PDF outputs only, but also inserts some details into HTML outputs, such as version and build information.
 include::home::partial$colophon.adoc[]
-endif::[]
 
-// Table of contents: Not relevant for HTML output. Make sure that this code is *after* all content that we want to treat as frontmatter in the PDF output.
-ifdef::loader-assembler[]
-include::home::partial$toc.adoc[]
-endif::[]
-
-[discrete]
+// For PDF output, the content below will appear as preface followed by the table of contents.
 == The rules for setup and scenarios
 
 Here you'll find guidance and ideas on how to set up a game of {project-name}.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -17,7 +17,8 @@ ifdef::loader-assembler[]
 include::home::partial$toc.adoc[]
 endif::[]
 
-== {project-name}: Battles -- the scenarios and setup for play
+[discrete]
+== The rules for setup and scenarios
 
 Here you'll find guidance and ideas on how to set up a game of {project-name}.
 You'll also find scenario special rules; these are particular to some scenarios, so we detail them here rather than in the _Core_ component.

--- a/modules/experimental/nav.adoc
+++ b/modules/experimental/nav.adoc
@@ -1,1 +1,1 @@
-* xref:experimental.adoc[_Experimental_]
+//* xref:experimental.adoc[_Experimental_]

--- a/modules/scenario-special-rules/pages/drop-pods.adoc
+++ b/modules/scenario-special-rules/pages/drop-pods.adoc
@@ -93,6 +93,6 @@ Place the appropriate Order marker, if you haven't already.
 .Related information
 * xref:core:special-rules:deep-strike.adoc[]
 * xref:scenario-special-rules:reserves.adoc[]
-* xref:core:ROOT:what-you-will-need-to-play.adoc#drop-pods-tokens[Drop Pods tokens]
-* xref:core:ROOT:what-you-will-need-to-play.adoc#barrage-templates[Barrage templates]
+* xref:core:basics:what-you-will-need-to-play.adoc#drop-pods-tokens[Drop Pods tokens]
+* xref:core:basics:what-you-will-need-to-play.adoc#barrage-templates[Barrage templates]
 * xref:core:main-rules:terrain-effects-on-movement.adoc[]

--- a/modules/scenario-special-rules/pages/drop-pods.adoc
+++ b/modules/scenario-special-rules/pages/drop-pods.adoc
@@ -5,7 +5,7 @@ Drop pods are single-use planetary landing craft which afford commanders the mea
 NOTE: We also use the Drop Pods rules to represent some other technologies that perform a similar function.
 
 [NOTE.option]
-.Drop pods miniatures
+.Option: Drop pods miniatures
 ====
 You do not need to have any miniatures to represent drop pods.
 But, if you have some and you enjoy the spectacle, it can be fun to use them -- and if your opponent agrees, you could allow infantry to use them as cover.

--- a/modules/scenario-special-rules/pages/hidden-setup.adoc
+++ b/modules/scenario-special-rules/pages/hidden-setup.adoc
@@ -92,4 +92,4 @@ So, we phrased the text in a way that makes this clear.
 ]
 
 .Related information
-* xref:core:ROOT:what-you-will-need-to-play.adoc#hidden-setup-markers[Hidden Setup markers]
+* xref:core:basics:what-you-will-need-to-play.adoc#hidden-setup-markers[Hidden Setup markers]

--- a/modules/scenario-special-rules/pages/objectives.adoc
+++ b/modules/scenario-special-rules/pages/objectives.adoc
@@ -127,5 +127,5 @@ Then remove the objective marker from the playing area.
 ---
 
 .Related information
-* xref:core:ROOT:what-you-will-need-to-play.adoc#objective-markers[Objective markers]
+* xref:core:basics:what-you-will-need-to-play.adoc#objective-markers[Objective markers]
 * xref:core:main-rules:terrain-effects-on-shooting.adoc#infantry-armour-bonus[Armour bonus for infantry that are in cover]

--- a/modules/scenarios/nav.adoc
+++ b/modules/scenarios/nav.adoc
@@ -13,4 +13,4 @@
   *** xref:battle-5-ambush.adoc[]
   *** xref:battle-6-planetary-assault.adoc[]
  ** xref:the-fog-of-war.adoc[]
-** xref:more-scenarios.adoc[]
+//** xref:more-scenarios.adoc[]

--- a/modules/scenarios/pages/refight-4-the-sulphur-river.adoc
+++ b/modules/scenarios/pages/refight-4-the-sulphur-river.adoc
@@ -86,7 +86,7 @@ When the game ends, determine the result as follows:
 * If the opposing players each control one bridge, or dispute both bridges, then the result is a draw.
 
 [NOTE.option]
-.Victory or Death!
+.Option: Victory or Death!
 ====
 For a real bloodbath, if both players agree, ignore the limit of D3+3 turns.
 Instead, play this scenario for as many turns as it takes until one player can claim victory by virtue of the fact that their opponent has no units left!


### PR DESCRIPTION
Local build is working well to preview HTML website output and PDF outputs. It's time to try the changes on the production site.

Complete final checks of changes in each project repo, and then merge them all into their main branches at the same time — and be ready to debug, or in the worst case, roll back.